### PR TITLE
Reduce data transfer and speed up usage of Knapsack Pro API for Queue Mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -808,9 +808,9 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-63kJpA4gEcSLLibQaKGr/nEKY2CZWkKYYKpIU8vtFCRu9ORIjX0k5rdp+0Gsckdm/QmJ/S4F7GxH0HZu+sFWrQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-pnZW/PPM5GE0OkrryxFkRVrtTMBADQrIDguSWonl+nZlw1vmkv6MaquL+z9HYd85IPt0JnvgKROI4NKu5YMq+g==",
       "requires": {
         "axios": "^0.18.0",
         "axios-retry": "^3.1.1",
@@ -11893,9 +11893,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "knapsack-pro-jest": "lib/knapsack-pro-jest.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.2.0",
+    "@knapsack-pro/core": "^1.3.0",
     "glob": "^7.1.3",
     "jest": "^23.6.0"
   },


### PR DESCRIPTION
* Update `@knapsack-pro/core` to 1.3.0. Related to https://github.com/KnapsackPro/knapsack-pro-core-js/pull/12

Don’t send test_files for already initialized Queue. Thanks to that we
reduce data transfer. This also makes requests much faster (even 10
times faster for test suite with 5000 test files).