### PR TITLE
Add support for Jest CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Learn about Knapsack Pro Queue Mode in the video [how to run tests with dynamic 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-## Table of Contents
-
 - [Installation](#installation)
 - [How to use](#how-to-use)
   - [Configuration steps](#configuration-steps)
@@ -34,6 +32,7 @@ Learn about Knapsack Pro Queue Mode in the video [how to run tests with dynamic 
 - [FAQ](#faq)
   - [Knapsack Pro Core features FAQ](#knapsack-pro-core-features-faq)
   - [How to run tests only from specific directory?](#how-to-run-tests-only-from-specific-directory)
+  - [How to pass command line options?](#how-to-pass-command-line-options)
 - [Development](#development)
   - [Dependencies](#dependencies)
   - [Setup](#setup)
@@ -465,6 +464,16 @@ This project depends on `@knapsack-pro/core`. Please check the [FAQ for `@knapsa
 You can set `KNAPSACK_PRO_TEST_FILE_PATTERN={**/__tests__/**/*.js?(x),**/?(*.)(spec|test).js?(x)}` and change pattern to match your directory with test files. You can use [glob](https://github.com/isaacs/node-glob) pattern.
 
 `@knapsack-pro/jest` by default rejects tests inside of `node_modules` directory. If your pattern set by `KNAPSACK_PRO_TEST_FILE_PATTERN` matches test file paths within `node_modules` then those test file paths won't be run.
+
+### How to pass command line options?
+
+You can pass command line options to Jest by just passing them to `@knapsack-pro/jest`. See example:
+
+```
+$(npm bin)/knapsack-pro-jest --debug
+```
+
+You can find [list of Jest CLI options here](https://jestjs.io/docs/en/cli#options).
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8206,9 +8206,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -8235,6 +8235,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "ms": {
@@ -8653,6 +8660,11 @@
         "wordwrap": "~0.0.2"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   "dependencies": {
     "@knapsack-pro/core": "^1.4.0",
     "glob": "^7.1.3",
-    "jest": "^24.8.0"
+    "jest": "^24.8.0",
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",

--- a/src/jest-cli.ts
+++ b/src/jest-cli.ts
@@ -1,0 +1,10 @@
+const minimist = require('minimist');
+
+// https://jestjs.io/docs/en/cli#options
+export class JestCLI {
+  public static argvToOptions(): object {
+    const argv = process.argv.slice(2);
+
+    return minimist(argv);
+  }
+}

--- a/src/knapsack-pro-jest.ts
+++ b/src/knapsack-pro-jest.ts
@@ -6,12 +6,20 @@ const jest = require('jest');
 
 import {
   KnapsackProCore,
+  KnapsackProLogger,
   onQueueFailureType,
   onQueueSuccessType,
   TestFile,
 } from '@knapsack-pro/core';
 import { EnvConfig } from './env-config';
 import { TestFilesFinder } from './test-files-finder';
+import { JestCLI } from './jest-cli';
+
+const jestCLIOptions = JestCLI.argvToOptions();
+const knapsackProLogger = new KnapsackProLogger();
+knapsackProLogger.debug(
+  `Jest CLI options:\n${KnapsackProLogger.objectInspect(jestCLIOptions)}`,
+);
 
 EnvConfig.loadEnvironmentVariables();
 
@@ -29,9 +37,14 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
   );
   const {
     results: { success: isTestSuiteGreen, testResults },
-  } = await jest.runCLI({ runTestsByPath: true, _: testFilePaths }, [
-    projectPath,
-  ]);
+  } = await jest.runCLI(
+    {
+      ...jestCLIOptions,
+      runTestsByPath: true,
+      _: testFilePaths,
+    },
+    [projectPath],
+  );
 
   const recordedTestFiles: TestFile[] = testResults.map(
     ({


### PR DESCRIPTION
You can pass Jest CLI options to `@knapsack-pro/jest`. Example:

```
$(npm bin)/knapsack-pro-jest --debug
```

Jest CLI options list: https://jestjs.io/docs/en/cli#options