### PR TITLE
Update @knapsack-pro/core 1.5.0 to add support for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Learn about Knapsack Pro Queue Mode in the video [how to run tests with dynamic 
       - [Semaphore 1.0](#semaphore-10)
     - [Cirrus-CI.org](#cirrus-ciorg)
     - [Jenkins](#jenkins)
+    - [GitHub Actions](#github-actions)
     - [Other CI provider](#other-ci-provider)
 - [FAQ](#faq)
   - [Knapsack Pro Core features FAQ](#knapsack-pro-core-features-faq)
@@ -438,6 +439,58 @@ timeout(time: 60, unit: 'MINUTES') {
 ```
 
 Remember to set environment variable `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` in Jenkins configuration with your API token.
+
+#### GitHub Actions
+
+`@knapsack-pro/jest` supports environment variables provided by GitHub Actions to run your tests. You have to define a few things in `.github/workflows/main.yaml` config file.
+
+- You need to set `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST`. See [creating and using secrets in GitHub Actions](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables).
+- You should create as many parallel jobs as you need with `matrix.ci_node_total` and `matrix.ci_node_index` properties. If your test suite is slow you should use more parallel jobs.
+
+Below you can find config for GitHub Actions.
+
+```yaml
+# .github/workflows/main.yaml
+name: Main
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x]
+        # Set N number of parallel jobs you want to run tests on.
+        # Use higher number if you have slow tests to split them on more parallel jobs.
+        # Remember to update ci_node_index below to 0..N-1
+        ci_node_total: [2]
+        # set N-1 indexes for parallel jobs
+        # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
+        ci_node_index: [0, 1]
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build --if-present
+
+      - name: Run tests with Knapsack Pro
+        env:
+          KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST }}
+          KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        run: |
+          $(npm bin)/knapsack-pro-jest
+```
 
 #### Other CI provider
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1112,9 +1112,9 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.4.1.tgz",
-      "integrity": "sha512-phOpabQENPtw/+D9lF7mN1lEdCHLSAploL5r2IygM1d3SI+pxB0itIFm7fMe8CszuF5qROW2mDjf0gpPqsSnOg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-pvFeU9nnN009tnwyDGbiHZE7kWIXUjtNxMJCcin8wzRjNQ7b/+DpANSAXGi2/kz+OWx3pj/f7s9mOvAqs0ok2g==",
       "requires": {
         "axios": "0.18.0",
         "axios-retry": "^3.1.2",
@@ -4044,9 +4044,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fault": {
       "version": "1.0.2",
@@ -4465,9 +4465,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
-      "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
       "requires": {
         "debug": "^3.0.0"
       }
@@ -6126,9 +6126,9 @@
       "dev": true
     },
     "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-stream": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "knapsack-pro-jest": "lib/knapsack-pro-jest.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.4.1",
+    "@knapsack-pro/core": "^1.5.0",
     "glob": "^7.1.3",
     "jest": "^24.8.0",
     "minimist": "^1.2.0"


### PR DESCRIPTION
Add support for GitHub Actions as CI provider.

Related changes in `@knapsack-pro/core`: 
https://github.com/KnapsackPro/knapsack-pro-core-js/pull/16