### PR TITLE
Add support for Codefresh.io CI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Learn about Knapsack Pro Queue Mode in the video [how to run tests with dynamic 
     - [Cirrus-CI.org](#cirrus-ciorg)
     - [Jenkins](#jenkins)
     - [GitHub Actions](#github-actions)
+    - [Codefresh.io](#codefreshio)
     - [Other CI provider](#other-ci-provider)
 - [FAQ](#faq)
   - [Knapsack Pro Core features FAQ](#knapsack-pro-core-features-faq)
@@ -98,6 +99,7 @@ Whenever you see `npm` in below steps you can use `yarn` there as well.
    - [SemaphoreCI.com](#semaphorecicom)
    - [Cirrus-CI.org](#cirrus-ciorg)
    - [Jenkins](#jenkins)
+   - [Codefresh.io](#codefreshio)
    - [Other CI provider](#other-ci-provider)
 
 ### CI steps
@@ -491,6 +493,84 @@ jobs:
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         run: |
           $(npm bin)/knapsack-pro-jest
+```
+
+#### Codefresh.io
+
+`@knapsack-pro/jest` supports environment variables provided by Codefresh.io to run your tests. You have to define a few things in `.codefresh/codefresh.yml` config file.
+
+- You need to set an API token `KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST` in Codefresh dashboard, see left menu Pipelines -> settings (cog icon next to the pipeline) -> Variables tab (see a vertical menu on the right side).
+- Set where Codefresh YAML file can be found. In Codefresh dashboard, see left menu Pipelines -> settings (cog icon next to pipeline) -> Workflow tab (horizontal menu on the top) -> Path to YAML (set there `./.codefresh/codefresh.yml`).
+- Set how many parallel jobs (parallel CI nodes) you want to run with `KNAPSACK_PRO_CI_NODE_TOTAL` environment variable in `.codefresh/codefresh.yml` file.
+- Ensure in the `matrix` section you listed all `KNAPSACK_PRO_CI_NODE_INDEX` environment variables with a value from `0` to `KNAPSACK_PRO_CI_NODE_TOTAL-1`. Codefresh will generate a matrix of parallel jobs where each job has a different value for `KNAPSACK_PRO_CI_NODE_INDEX`. Thanks to that Knapsack Pro knows what tests should be run on each parallel job.
+
+Below you can find Codefresh YAML config and `Test.Dockerfile` used by Codefresh to run the project and Jest test suite inside of Docker container.
+
+```yaml
+# .codefresh/codefresh.yml
+version: "1.0"
+
+stages:
+  - "clone"
+  - "build"
+  - "tests"
+
+steps:
+  main_clone:
+    type: "git-clone"
+    description: "Cloning main repository..."
+    repo: "${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}"
+    revision: "${{CF_BRANCH}}"
+    stage: "clone"
+  BuildTestDockerImage:
+    title: Building Test Docker image
+    type: build
+    arguments:
+      image_name: "${{CF_ACCOUNT}}/${{CF_REPO_NAME}}-test"
+      tag: "${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}"
+      dockerfile: Test.Dockerfile
+    stage: "build"
+
+  run_tests:
+    stage: "tests"
+    image: "${{BuildTestDockerImage}}"
+    working_directory: /src
+    fail_fast: false
+    environment:
+      # set how many parallel jobs you want to run
+      - KNAPSACK_PRO_CI_NODE_TOTAL=2
+    matrix:
+      environment:
+        # please ensure you have here listed N-1 indexes
+        # where N is KNAPSACK_PRO_CI_NODE_TOTAL
+        - KNAPSACK_PRO_CI_NODE_INDEX=0
+        - KNAPSACK_PRO_CI_NODE_INDEX=1
+    commands:
+      - $(npm bin)/knapsack-pro-jest
+```
+
+Add `Test.Dockerfile` to your project repository.
+
+```Dockerfile
+FROM node:10.13
+
+RUN apt-get update && \
+  apt-get install -y \
+  python3-dev \
+  python3-pip
+
+# Install AWS CLI
+RUN pip3 install awscli
+
+# Install Codefresh CLI
+RUN wget https://github.com/codefresh-io/cli/releases/download/v0.31.1/codefresh-v0.31.1-alpine-x64.tar.gz
+RUN tar -xf codefresh-v0.31.1-alpine-x64.tar.gz -C /usr/local/bin/
+
+COPY . /src
+
+WORKDIR /src
+
+RUN npm install
 ```
 
 #### Other CI provider

--- a/package-lock.json
+++ b/package-lock.json
@@ -1112,9 +1112,9 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-pvFeU9nnN009tnwyDGbiHZE7kWIXUjtNxMJCcin8wzRjNQ7b/+DpANSAXGi2/kz+OWx3pj/f7s9mOvAqs0ok2g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-wQ43gfxcMZpq88qCMi1vwX0AyfgDewoxBklPyS/VOAK1YIcg5NculzM9bcORXTPRSpkF7As+Vy7tExtUraSj3Q==",
       "requires": {
         "axios": "0.18.0",
         "axios-retry": "^3.1.2",
@@ -2767,9 +2767,9 @@
       "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "colorspace": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "knapsack-pro-jest": "lib/knapsack-pro-jest.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.5.0",
+    "@knapsack-pro/core": "^1.6.0",
     "glob": "^7.1.3",
     "jest": "^24.8.0",
     "minimist": "^1.2.0"


### PR DESCRIPTION
* Add support for Codefresh.io CI provider
* Update `@knapsack-pro/core` 1.6.0
Related PR https://github.com/KnapsackPro/knapsack-pro-core-js/pull/17