### PR TITLE
Run tests only when they are detected on the disk. Do not run tests when the test file pattern is invalid. Require to set KNAPSACK_PRO_TEST_FILE_PATTERN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1112,11 +1112,11 @@
       }
     },
     "@knapsack-pro/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-wQ43gfxcMZpq88qCMi1vwX0AyfgDewoxBklPyS/VOAK1YIcg5NculzM9bcORXTPRSpkF7As+Vy7tExtUraSj3Q==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@knapsack-pro/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-HyMIVNZ/pH+f9XvJCQl1k8Le5Wx/4V4eVFl09BU/upAopUiEqcNVJuIpjdB3bo8zl3vIWVXGEa6cO1Rfh7NbOA==",
       "requires": {
-        "axios": "0.18.0",
+        "axios": "0.18.1",
         "axios-retry": "^3.1.2",
         "winston": "^3.1.0"
       }
@@ -1906,13 +1906,6 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
         "lodash": "^4.17.14"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        }
       }
     },
     "async-done": {
@@ -1968,12 +1961,19 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
       }
     },
     "axios-retry": {
@@ -3248,7 +3248,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -4078,7 +4078,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "file-entry-cache": {
@@ -4476,11 +4476,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
-      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "^3.0.0"
+        "debug": "=3.1.0"
       }
     },
     "for-in": {
@@ -4554,8 +4554,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4573,13 +4572,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4592,18 +4589,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4706,8 +4700,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4717,7 +4710,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4730,20 +4722,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4760,7 +4749,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4839,8 +4827,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4850,7 +4837,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4926,8 +4912,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4957,7 +4942,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4975,7 +4959,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5014,13 +4997,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -12243,7 +12224,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -12257,7 +12238,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "knapsack-pro-jest": "lib/knapsack-pro-jest.js"
   },
   "dependencies": {
-    "@knapsack-pro/core": "^1.6.0",
+    "@knapsack-pro/core": "^1.6.1",
     "glob": "^7.1.3",
     "jest": "^24.8.0",
     "minimatch": "^3.0.4",

--- a/src/test-files-finder.ts
+++ b/src/test-files-finder.ts
@@ -1,12 +1,12 @@
 import glob = require('glob');
 import minimatch = require('minimatch');
 
-import { TestFile } from '@knapsack-pro/core';
+import { KnapsackProLogger, TestFile } from '@knapsack-pro/core';
 import { EnvConfig } from './env-config';
 
 export class TestFilesFinder {
   public static allTestFiles(): TestFile[] {
-    return glob
+    const testFiles = glob
       .sync(EnvConfig.testFilePattern)
       .filter((testFilePath: string) => {
         if (EnvConfig.testFileExcludePattern) {
@@ -22,5 +22,18 @@ export class TestFilesFinder {
         return !testFilePath.match(/node_modules/);
       })
       .map((testFilePath: string) => ({ path: testFilePath }));
+
+    if (testFiles.length === 0) {
+      const knapsackProLogger = new KnapsackProLogger();
+
+      const errorMessage =
+        // tslint:disable-next-line: max-line-length
+        'Test files cannot be found.\nPlease set KNAPSACK_PRO_TEST_FILE_PATTERN matching your test directory structure.\nLearn more: https://github.com/KnapsackPro/knapsack-pro-jest#how-to-run-tests-only-from-specific-directory';
+
+      knapsackProLogger.error(errorMessage);
+      throw errorMessage;
+    }
+
+    return testFiles;
   }
 }


### PR DESCRIPTION
# Problem

When a user has test files in a non-standard directory then Knapsack Pro can't find test files so the empty array of tests is sent to Knapsack Pro API Queue. API returns an error so Knapsack Pro switches to Fallback Mode and runs the whole test suite on a single node because the empty list of tests was set for Jest CLI which means Jest should run all tests. It leads to all parallel CI nodes to run the whole test suite.

```
2019-11-21T22:30:08.075Z [@knapsack-pro/core] info: POST http://api.knapsackpro.test:3000/v1/queues/queue

2019-11-21T22:30:08.269Z [@knapsack-pro/core] error: 422 Unprocessable Entity

Request ID:
29b25da6-4811-48bb-9e14-b0d254bdb1e0

Response body:
{ errors: [ { test_files: [ 'parameter is required' ] } ] }

2019-11-21T22:30:08.269Z [@knapsack-pro/core] warn: Fallback Mode has started. We could not connect to Knapsack Pro API. Your tests will be executed based on test file names.

If other CI nodes were able to connect to Knapsack Pro API then you may notice that some of the test files were executed twice across CI nodes. Fallback Mode guarantees each of test files is run at least once as a part of CI build.
 PASS  __tests__/directory/c.test.js
 PASS  __tests__/b.spec.js
 PASS  __tests__/a.test.js

Test Suites: 3 passed, 3 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        5.577s
Ran all test suites within paths .

...
```

# Solution

* Do not run tests when the test file pattern is invalid. 
* Show error message about `KNAPSACK_PRO_TEST_FILE_PATTERN` being required.
* Show link to https://github.com/KnapsackPro/knapsack-pro-jest#how-to-run-tests-only-from-specific-directory

Thanks to this a user who has a test suite in a non-standard directory won't be accidentally running tests in Fallback Mode. Users will see meaningful error with tips on what to do to fix the problem.

# Other changes
* Update `@knapsack-pro/core` to 1.6.1 https://github.com/KnapsackPro/knapsack-pro-core-js/blob/master/CHANGELOG.md#v161-2019-11-04