### PR TITLE
Add KNAPSACK_PRO_COVERAGE_DIRECTORY to generate unique directory name with code coverage reports for each batch of tests fetched from Queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ Whenever you see `npm` in below steps you can use `yarn` there as well.
 
 5. If you want to use [Jest config file with `@knapsack-pro/jest`](https://knapsackpro.com/faq/question/how-to-use-jest-config-file-with-knapsack-pro-jest) check this tip.
 
-6. If you use `jest-junit` please check [how to generate XML report using `jest-junit` with `@knapsack-pro/jest` in Queue Mode](https://knapsackpro.com/faq/question/how-to-generate-xml-report-using-jest-junit-with-knapsack-pro-jest-in-queue-mode)?
+6. If you use `--coverage` flag for Jest to generate code coverage then to make it work please check [how to generate code coverage for Jest with `@knapsack-pro/jest` in Queue Mode](https://knapsackpro.com/faq/question/how-to-generate-code-coverage-for-jest-with-knapsack-pro-jest-in-queue-mode)?
 
-7. Please select your CI provider and follow instructions to run tests with `@knapsack-pro/jest`.
+7. If you use `jest-junit` please check [how to generate XML report using `jest-junit` with `@knapsack-pro/jest` in Queue Mode](https://knapsackpro.com/faq/question/how-to-generate-xml-report-using-jest-junit-with-knapsack-pro-jest-in-queue-mode)?
+
+8. Please select your CI provider and follow instructions to run tests with `@knapsack-pro/jest`.
 
    - [CircleCI](#circleci)
    - [Travis CI](#travis-ci)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3248,7 +3248,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -4078,7 +4078,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "file-entry-cache": {
@@ -11931,9 +11931,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8flags": {
       "version": "3.0.1",
@@ -12238,7 +12238,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "glob": "^7.1.3",
     "jest": "^24.8.0",
     "minimatch": "^3.0.4",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",

--- a/src/env-config.ts
+++ b/src/env-config.ts
@@ -23,4 +23,8 @@ export class EnvConfig {
   public static get testFileExcludePattern(): void | string {
     return process.env.KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN;
   }
+
+  public static get coverageDirectory(): void | string {
+    return process.env.KNAPSACK_PRO_COVERAGE_DIRECTORY;
+  }
 }

--- a/src/knapsack-pro-jest.ts
+++ b/src/knapsack-pro-jest.ts
@@ -35,11 +35,21 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
   const testFilePaths: string[] = queueTestFiles.map(
     (testFile: TestFile) => testFile.path,
   );
+
+  let jestCLICoverage = {};
+  if (EnvConfig.coverageDirectory) {
+    jestCLICoverage = {
+      // TODO add UUID to the path name
+      coverageDirectory: EnvConfig.coverageDirectory,
+    };
+  }
+
   const {
     results: { success: isTestSuiteGreen, testResults },
   } = await jest.runCLI(
     {
       ...jestCLIOptions,
+      ...jestCLICoverage,
       runTestsByPath: true,
       _: testFilePaths,
     },

--- a/src/knapsack-pro-jest.ts
+++ b/src/knapsack-pro-jest.ts
@@ -37,12 +37,11 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
     (testFile: TestFile) => testFile.path,
   );
 
-  let jestCLICoverage = {};
-  if (EnvConfig.coverageDirectory) {
-    jestCLICoverage = {
+  const jestCLICoverage = EnvConfig.coverageDirectory
+    ? {
       coverageDirectory: `${EnvConfig.coverageDirectory}/${uuidv1()}`,
-    };
-  }
+    }
+    : {};
 
   const {
     results: { success: isTestSuiteGreen, testResults },

--- a/src/knapsack-pro-jest.ts
+++ b/src/knapsack-pro-jest.ts
@@ -3,6 +3,7 @@
 const { name: clientName, version: clientVersion } = require('../package.json');
 
 const jest = require('jest');
+const uuidv1 = require('uuid/v1');
 
 import {
   KnapsackProCore,
@@ -39,8 +40,7 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
   let jestCLICoverage = {};
   if (EnvConfig.coverageDirectory) {
     jestCLICoverage = {
-      // TODO add UUID to the path name
-      coverageDirectory: EnvConfig.coverageDirectory,
+      coverageDirectory: `${EnvConfig.coverageDirectory}/${uuidv1()}`,
     };
   }
 


### PR DESCRIPTION
This is a fix for problem https://github.com/KnapsackPro/knapsack-pro-jest/issues/12

In test repo, I added example to test that when developing this lib:
https://github.com/KnapsackPro/jest-example-test-suite/blob/master/bin/knapsack_pro_jest_coverage

# FAQ - must read
Here is info how to use it: https://knapsackpro.com/faq/question/how-to-generate-code-coverage-for-jest-with-knapsack-pro-jest-in-queue-mode