### PR TITLE
Default NODE_ENV to 'test'

### DIFF
--- a/src/env-config.ts
+++ b/src/env-config.ts
@@ -4,6 +4,10 @@ export class EnvConfig {
       process.env.KNAPSACK_PRO_TEST_SUITE_TOKEN =
         process.env.KNAPSACK_PRO_TEST_SUITE_TOKEN_JEST;
     }
+
+    if (process.env.NODE_ENV == null) {
+      process.env.NODE_ENV = 'test';
+    }
   }
 
   public static get testFilePattern(): string {


### PR DESCRIPTION
Jest defaults `NODE_ENV` to `test`, and they suggest that you can rely on this to set up Jest-specific Babel config:

https://jestjs.io/docs/en/getting-started.html#using-babel
>Jest will set process.env.NODE_ENV to 'test' if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest

https://github.com/facebook/jest/blob/f6366db60e32f1763e612288bf3984bcfa7a0a15/packages/jest-runtime/bin/jest-runtime.js#L9-L11

knapsack-pro-jest doesn't currently do this, which means that Babel config set up in this way breaks until you set `NODE_ENV` yourself.