### PR TITLE
Use 0 seconds as a default test file time execution

### DIFF
--- a/src/knapsack-pro-jest.ts
+++ b/src/knapsack-pro-jest.ts
@@ -66,9 +66,8 @@ const onSuccess: onQueueSuccessType = async (queueTestFiles: TestFile[]) => {
           ? testFilePath.replace(`${projectPath}\\`, '').replace(/\\/g, '/')
           : testFilePath.replace(`${projectPath}/`, '');
       const timeExecutionMiliseconds = end - start;
-      // 0.1s default time when not recorded timing
       const timeExecution =
-        timeExecutionMiliseconds > 0 ? timeExecutionMiliseconds / 1000 : 0.1;
+        timeExecutionMiliseconds > 0 ? timeExecutionMiliseconds / 1000 : 0.0;
 
       return {
         path,


### PR DESCRIPTION
Use 0 seconds as a default test file time execution instead of 0.1s because Knapsack Pro API already accepts 0 seconds value.

# Related change in knapsack_pro ruby gem
https://github.com/KnapsackPro/knapsack_pro-ruby/pull/140