### PR TITLE
Update peerDependencies to allow Jest 29.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typescript": "^4.7.3"
       },
       "peerDependencies": {
-        "jest": ">=22.0.0 <29.0.0"
+        "jest": ">=22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "jest": ">=22.0.0 <29.0.0"
+    "jest": ">=22.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",


### PR DESCRIPTION
Update peerDependencies to allow Jest 29.x

# related issue

* https://github.com/KnapsackPro/knapsack-pro-jest/issues/63