### PR TITLE
Permalinks

### DIFF
--- a/src/test-files-finder.ts
+++ b/src/test-files-finder.ts
@@ -3,6 +3,7 @@ import minimatch = require('minimatch');
 
 import { KnapsackProLogger, TestFile } from '@knapsack-pro/core';
 import { EnvConfig } from './env-config';
+import * as Urls from './urls';
 
 export class TestFilesFinder {
   public static allTestFiles(): TestFile[] {
@@ -27,8 +28,7 @@ export class TestFilesFinder {
     if (testFiles.length === 0) {
       const knapsackProLogger = new KnapsackProLogger();
 
-      const errorMessage =
-        'Test files cannot be found.\nPlease set KNAPSACK_PRO_TEST_FILE_PATTERN matching your test directory structure.\nLearn more: https://knapsackpro.com/faq/question/how-to-run-tests-only-from-specific-directory-in-jest';
+      const errorMessage = `Test files cannot be found.\nPlease set KNAPSACK_PRO_TEST_FILE_PATTERN matching your test directory structure.\nLearn more: ${Urls.NO_TESTS_FOUND}`;
 
       knapsackProLogger.error(errorMessage);
       throw errorMessage;

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,0 +1,2 @@
+export const NO_TESTS_FOUND =
+  'https://knapsackpro.com/perma/jest/no-tests-found';


### PR DESCRIPTION
Same as https://github.com/KnapsackPro/knapsack_pro-ruby/pull/187

The redirect is deployed to production, so you can already tests the link.

See also
- https://github.com/KnapsackPro/knapsack-pro-cypress/pull/92
- https://github.com/KnapsackPro/knapsack-pro-api/pull/634